### PR TITLE
build(dependencies): 🧱 update crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "litemap"
@@ -392,7 +392,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "rustc-hash",
- "thiserror",
+ "thiserror 1.0.69",
  "xmlparser",
 ]
 
@@ -456,7 +456,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "textwrap",
- "thiserror",
+ "thiserror 2.0.3",
  "url",
  "wasm-bindgen",
 ]
@@ -765,18 +765,38 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,6 @@ pulldown-cmark = "0.9.2"
 serde = { version = "1.0.214", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 textwrap = "0.16.1"
-thiserror = "1.0.67"
+thiserror = "2.0.3"
 url = "2.5.0"
 wasm-bindgen = { version = "=0.2.92", features = ["serde-serialize"] }


### PR DESCRIPTION
# Description

Update dependencies:

Bumps thiserror from 1.0.68 to 2.0.3.
    Updating libc v0.2.161 -> v0.2.162
    Updating thiserror v1.0.68 -> v1.0.69 (latest: v2.0.3)
    Updating thiserror-impl v1.0.68 -> v1.0.69 (latest: v2.0.3)

## Type of change

- [X] Dependency update

# How Has This Been Tested?

- [ ] cargo test run with all tests passing

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
