### PR TITLE
build(dependencies): 🧱 update crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,9 +137,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "html5ever"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff6858c1f7e2a470c5403091866fa95b36fe0dbac5d771f932c15e5ff1ee501"
+checksum = "2e15626aaf9c351bc696217cbe29cb9b5e86c43f8a46b5e2f5c6c5cf7cb904ce"
 dependencies = [
  "log",
  "mac",
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
 
 [[package]]
 name = "litemap"
@@ -358,9 +358,9 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markup5ever"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d581ff8be69d08a2efa23a959d81aa22b739073f749f067348bd4f4ba4b69195"
+checksum = "82c88c6129bd24319e62a0359cb6b958fa7e8be6e19bb1663bc396b90883aca5"
 dependencies = [
  "log",
  "phf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ lto = true
 opt-level = "z"
 
 [dependencies]
-aho-corasick = "1.1.2"
+aho-corasick = "1.1.3"
 deunicode = "1.6.0"
 getrandom = { version = "0.2.15", features = ["js"] }
-html5ever = "0.28.0"
+html5ever = "0.29.0"
 js-sys = "0.3.69"
 mrml = { version = "4.0.1", features = ["parse", "render"], default-features = false }
 nom = { version = "7.1.3", features = ["alloc"] }

--- a/src/html_process/dom.rs
+++ b/src/html_process/dom.rs
@@ -158,7 +158,10 @@ impl TreeSink for RcDom {
     fn finish(self) -> Self {
         self
     }
+
     type Handle = Handle;
+
+    type ElemName<'a>=ExpandedName<'a> where Self: 'a;
 
     fn parse_error(&self, msg: Cow<'static, str>) {
         self.errors.borrow_mut().push(msg);


### PR DESCRIPTION
# Description

Update dependencies:

Bumps html5ever from 0.28.0 to 0.29.0.
    Updating itoa v1.0.13 -> v1.0.14
    Updating libc v0.2.164 -> v0.2.166

## Type of change

- [X] Dependency update

# How Has This Been Tested?

- [X] cargo test run with all tests passing
- [X] Deno tests run and passed

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
